### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/assassin.gemspec
+++ b/assassin.gemspec
@@ -33,7 +33,6 @@ Gem::Specification::new do |spec|
 
   spec.extensions.push(*[])
 
-  spec.rubyforge_project = "codeforpeople"
   spec.author = "Ara T. Howard"
   spec.email = "ara.t.howard@gmail.com"
   spec.homepage = "https://github.com/ahoward/assassin"


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.